### PR TITLE
fix(interactive-mode): Fix filtering of options based on the prompt property

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ And then simply call your CLI with no parameters.
 
 ### Prompt just some questions (mixed mode)
 
-You can opt-out options from interactive mode by setting the `prompt` property to `never`.
+You can opt-out options from interactive mode by setting the `prompt` property to `never`. By default, its value is `if-empty`, prompting the question to the user if the value was not set via command line parameters or it doesn't have a default property. Last, you can use `always` to always prompt the option.
 
 **my-cli.js**
 ```js
@@ -139,8 +139,8 @@ const yargsInteractive = require('yargs-interactive');
 
 const options = {
   name: {
+    // prompt property if not set defaults to 'if-empty'
     type: 'input',
-    name: 'nano',
     describe: 'Enter your name'
   },
   likesPizza: {
@@ -163,12 +163,12 @@ yargsInteractive()
   });
 ```
 
- By default, its value is `if-empty`, prompting the question to the user if the value was not set via command line parameters or using the default property. Last, you can use `always` to always prompt the option.
-
 **Usage in terminal**
 ```
-➜ node my-cli.js --name='Johh' --interactive
+➜ node my-cli.js --interactive
 ```
+
+Notice that if you enter `node my-cli.js --name='Johh' --interactive` name won't be prompted either (as by default it uses `if-empty`).
 
 ### No prompt at all (ye olde yargs)
 
@@ -179,7 +179,7 @@ const yargsInteractive = require('yargs-interactive');
 const options = {
   name: {
     type: 'input',
-    name: 'nano',
+    default: 'nano',
     describe: 'Enter your name'
   },
   likesPizza: {

--- a/examples/mixed-mode.js
+++ b/examples/mixed-mode.js
@@ -12,7 +12,6 @@ const yargsInteractive = require('../src');
 const options = {
   name: {
     type: 'input',
-    default: 'nano',
     describe: 'Enter your name'
   },
   likesPizza: {
@@ -27,10 +26,9 @@ yargsInteractive()
   .usage('$0 <command> [args]')
   .interactive(options)
   .then((result) => {
-      console.log(
-        `\nResult is:\n`
-        + `- Name: ${result.name}\n`
-        + `- Likes pizza: ${result.likesPizza}\n`
-      );
+    console.log(
+      `\nResult is:\n`
+      + `- Name: ${result.name}\n`
+      + `- Likes pizza: ${result.likesPizza}\n`
+    );
   });
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,6 +165,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2355,7 +2356,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2616,6 +2618,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2817,7 +2820,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -3224,6 +3228,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4034,7 +4039,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -5181,7 +5187,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeating": {
       "version": "2.0.1",

--- a/src/yargs-interactive.js
+++ b/src/yargs-interactive.js
@@ -27,12 +27,22 @@ let yargsInteractive = (processArgs = process.argv.slice(2), cwd) => {
       .options(mergedOptions)
       .argv;
 
-    // Remove options with prompt value set to 'never'
-    // and options with prompt value set to 'if-empty' but no default value or value set via parameter
-    const interactiveOptions = filterObject(mergedOptions, (item, key) => (
-      item.prompt !== 'never'
-      && (item.prompt !== 'if-empty' || isEmpty(item.default) || isEmpty(argv[key]))
-    ));
+    // Filter options to prompt based on the "if-empty" property
+    const interactiveOptions = filterObject(mergedOptions, (item, key) => {
+      // Do not prompt items with prompt value set as "never"
+      if (item.prompt === 'never') {
+        return false;
+      }
+
+      // Prompt items with prompt value set as "always"
+      if (item.prompt === 'always') {
+        return true;
+      }
+
+      // Cases: item.prompt === "if-empty" or item.prompt undefined (fallbacks to "if-empty")
+      // Prompt the items that are empty (i.e. a value was not sent via parameter OR doesn't have a default value)
+      return isEmpty(argv[key]) && isEmpty(item.default);
+    });
 
     // Check if we should get the values from the interactive mode
     return argv.interactive

--- a/test/yargs-interactive.test.js
+++ b/test/yargs-interactive.test.js
@@ -138,6 +138,53 @@ describe('yargsInteractive', () => {
       });
     });
 
+    describe('and interactive parameters with prompt option', () => {
+      let expectedParameters;
+
+      before(() => {
+        options = {
+          directory: {
+            type: 'input',
+            default: '.',
+            describe: 'Target directory',
+          },
+          projectName: {
+            type: 'input',
+            describe: 'Project name',
+            prompt: 'if-empty',
+          },
+          user: {
+            type: 'input',
+            describe: 'user',
+            prompt: 'never'
+          },
+          password: {
+            type: 'input',
+            describe: 'user',
+            prompt: 'always'
+          },
+        };
+
+        expectedParameters = {directory: 'abc', projectName: 'def'};
+        return yargsInteractive(Object.keys(expectedParameters).map((key) => `--${key}=${expectedParameters[key]}`))
+          .usage('$0 <command> [args]')
+          .version()
+          .help()
+          .interactive(options)
+          .then((output) => result = output);
+      });
+
+      it('should return yargs default properties', () => {
+        checkProperties(result);
+      });
+
+      it('should return options with values sent by parameter', () => {
+        Object.keys(options).forEach((key) => {
+          assert.equal(result[key], expectedParameters[key], key);
+        });
+      });
+    });
+
     describe('and interactive option', () => {
       before(() => {
         const optionsWithInteractive = Object.assign({}, options, {interactive: {default: true}});


### PR DESCRIPTION
This PR fixes issue #13 by properly filtering the options using the `prompt` property.

It also updates the example and performs minor tweaks in the README.