### PR TITLE
chore(Travis): Bump node versions to 10.x and 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 language: node_js
 
 node_js:
+  - 10
   - 8
-  - 6
 
 cache:
   directories:
@@ -18,4 +18,3 @@ script:
 after_success:
   - npm run coveralls
   - npm run semantic-release
-


### PR DESCRIPTION
This PR simply upgrades Node version on Travis from `6 and 8` to `8 and 10`.