### PR TITLE
feat(interactive-mode): Added option to enable support of inquirer plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,26 @@ yargsInteractive()
 ```
 ➜ node my-cli.js --name='Johh' --likesPizza
 ```
+
+### Inquirer plugins support
+
+Inquirer plugins support must be opt-in by setting `allowInquirerPlugins` to `true` in the interactive mode options:
+
+```js
+const options = {
+  interactive: {
+    allowInquirerPlugins: true,
+    default: true,
+  },
+  ...
+};
+
+yargsInteractive()
+  .usage('$0 <command> [args]')
+  .interactive(options)
+  .then((result) => {
+    // The tool will prompt questions and will output your answers.
+    // TODO: Do something with the result (e.g result.name)
+    console.log(result)
+  });
+```

--- a/src/interactive-mode.js
+++ b/src/interactive-mode.js
@@ -5,8 +5,7 @@ const inquirer = require('inquirer');
  * @param {object} values The values to configure the prompt
  * @return {object} A promise that, when fullfilled, will contain answer of the questions prompted to the user
  */
-module.exports = (values = {}) => {
-  const prompt = inquirer.createPromptModule();
+module.exports = (values = {}, inquirerOptions = {}) => {
   const questions = Object.keys(values).map((key) => {
     const value = values[key];
     return Object.assign({}, value, {
@@ -16,6 +15,13 @@ module.exports = (values = {}) => {
       default: value.default
     });
   });
+
+  if (inquirerOptions.allowInquirerPlugins) {
+    return inquirer.prompt(questions);
+  }
+
+  // https://github.com/SBoudrias/Inquirer.js#inquirercreatepromptmodule---prompt-function
+  const prompt = inquirer.createPromptModule();
 
   return prompt(questions);
 };

--- a/src/yargs-interactive.js
+++ b/src/yargs-interactive.js
@@ -44,8 +44,13 @@ const yargsInteractive = (processArgs = process.argv.slice(2), cwd) => {
       return isEmpty(argv[key]) && isEmpty(item.default);
     });
 
+    // Assess self-contained mode -- Wheteher to create a self contained inquirer module or allow other libraries to be usable.
+    const inquirerOptions = {
+      allowInquirerPlugins: !!(options.interactive && options.interactive.allowInquirerPlugins)
+    };
+
     // Check if we should get the values from the interactive mode
-    return argv.interactive ? interactiveMode(interactiveOptions).then((result) => Object.assign({}, argv, result)) : Promise.resolve(argv);
+    return argv.interactive ? interactiveMode(interactiveOptions, inquirerOptions).then((result) => Object.assign({}, argv, result)) : Promise.resolve(argv);
   };
 
   return yargsConfig;


### PR DESCRIPTION
### Main changes ###

- Added option to enable support of `inquirer` plugins, which defaults to false when not provided. As the result, this PR preserves  backward-compatibility.